### PR TITLE
新增 Joseph 個人名片

### DIFF
--- a/NameCard/Jojo/JojoView.swift
+++ b/NameCard/Jojo/JojoView.swift
@@ -1,0 +1,178 @@
+//
+//  JojoView.swift
+//  NameCard
+//
+//  Created by Joseph-M2 on 2025/9/9.
+//
+
+import SwiftUI
+
+// 主視圖，用來呈現整張名片
+struct BusinessCardView: View {
+    
+    // MARK: - 屬性 (Properties)
+    
+    // 定義顏色以便重複使用，讓程式碼更乾淨
+    let cardBackgroundColor = Color(red: 0.16, green: 0.18, blue: 0.21)
+    let jsonKeyColor = Color(red: 0.98, green: 0.45, blue: 0.49)
+    let jsonValueColor = Color(red: 0.9, green: 0.75, blue: 0.48)
+    let defaultTextColor = Color.white.opacity(0.9)
+    let secondaryTextColor = Color.gray
+    let macRed = Color(red: 1.0, green: 0.37, blue: 0.34)
+    let macYellow = Color(red: 1.0, green: 0.74, blue: 0.22)
+    let macGreen = Color(red: 0.19, green: 0.8, blue: 0.43)
+
+    // MARK: - 視圖主體 (Body)
+    
+    var body: some View {
+        ZStack {
+            // 背景，模擬原始圖片中的暖色調背景
+            Color(red: 0.85, green: 0.78, blue: 0.7)
+                .ignoresSafeArea()
+
+            // 名片主體
+            VStack(alignment: .leading, spacing: 0) {
+                // 1. 標題列 (Title Bar)
+                titleBar
+                
+                // 2. 工具列 (Toolbar)
+                toolBar
+                
+                // 分隔線
+                Divider()
+                    .background(Color.gray.opacity(0.3))
+                    .padding(.horizontal)
+
+                // 3. 程式碼編輯區 (Code Area)
+                codeArea
+                    .padding()
+            }
+            .background(cardBackgroundColor)
+            .cornerRadius(16)
+            .shadow(color: .black.opacity(0.4), radius: 20, x: 0, y: 10)
+            .padding(30) // 讓名片與螢幕邊緣有些間距
+        }
+    }
+    
+    // MARK: - 子視圖 (Subviews)
+
+    /// 標題列，包含 macOS 風格的紅綠燈按鈕和檔案名稱
+    private var titleBar: some View {
+        HStack {
+            // 左側紅綠燈按鈕
+            HStack(spacing: 8) {
+                Circle().fill(macRed)
+                Circle().fill(macYellow)
+                Circle().fill(macGreen)
+            }
+            .frame(width: 60)
+            .padding(.leading)
+            
+            Spacer()
+            
+            // 中間檔案標題
+            Text("Name Card.json")
+                .font(.system(size: 14, weight: .medium, design: .monospaced))
+                .foregroundColor(secondaryTextColor)
+            
+            Spacer()
+
+            // 右側漢堡選單圖示
+            Image(systemName: "line.3.horizontal")
+                .foregroundColor(secondaryTextColor)
+                .frame(width: 60)
+        }
+        .frame(height: 40)
+    }
+    
+    /// 工具列，顯示各種編輯器圖示
+    private var toolBar: some View {
+        HStack(spacing: 18) {
+            Image(systemName: "arrow.uturn.backward")
+            Image(systemName: "doc.text")
+            Image(systemName: "curlybraces")
+            
+            HStack(spacing: 12) {
+                Image(systemName: "arrow.left")
+                Image(systemName: "arrow.right")
+                Rectangle()
+                    .fill(secondaryTextColor)
+                    .frame(width: 1, height: 16)
+            }
+
+            Spacer()
+
+            Image(systemName: "square")
+            Image(systemName: "ellipsis")
+        }
+        .font(.system(size: 14))
+        .foregroundColor(secondaryTextColor)
+        .padding(.horizontal)
+        .padding(.bottom, 8)
+    }
+
+    /// 程式碼編輯區，包含行號和 JSON 內容
+    private var codeArea: some View {
+        HStack(alignment: .top, spacing: 10) {
+            // 左側行號
+            VStack(alignment: .trailing, spacing: 4) {
+                // 圖片中的行號是不連續的，這裡忠實還原
+                Text("1")
+                Text("2")
+                Text("3")
+                Text("4") // title 的第二行沒有行號，所以這裡對應 linkedin
+                Text("5")
+                Text("6")
+                Text("7")
+            }
+            .font(.system(size: 16, design: .monospaced))
+            .foregroundColor(secondaryTextColor)
+            
+            // 右側 JSON 程式碼
+            VStack(alignment: .leading, spacing: 4) {
+//                Text("Business Card.json")
+                Text("{")
+                
+                // 使用 `+` 運算子組合不同顏色的 Text
+                Text("  \"name\": ")
+                    .foregroundColor(jsonKeyColor)
+                + Text("Joseph Tao")
+                    .foregroundColor(jsonValueColor)
+                
+                // 處理 title 的多行顯示
+                HStack(alignment: .top, spacing: 0) {
+                    Text("  \"title\": ")
+                        .foregroundColor(jsonKeyColor)
+                    
+                    HStack(alignment: .top, spacing: -30) {
+                        Text("Captain Mars Vessel ")
+                        Text("of the ")
+                    }
+                    .foregroundColor(jsonValueColor)
+                }
+                
+                HStack(alignment: .top, spacing: 0) {
+                    Text("  \"linkedin\": ")
+                        .foregroundColor(jsonKeyColor)
+                    
+                    HStack(alignment: .top, spacing: -10) {
+                        Text("linkedin in/jzzt")
+                        Text(".com/")
+                    }
+                        .foregroundColor(jsonValueColor)
+                }
+                Text("}")
+            }
+            .font(.system(size: 16, weight: .medium, design: .monospaced))
+            .foregroundColor(defaultTextColor)
+            // 使用 .leading 對齊，確保程式碼靠左
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}
+
+
+// MARK: - 預覽 (Preview)
+#Preview {
+    BusinessCardView()
+}

--- a/NameCard/Joseph/JosephView.swift
+++ b/NameCard/Joseph/JosephView.swift
@@ -133,7 +133,7 @@ struct NameCardView: View {
                 // 使用 `+` 運算子組合不同顏色的 Text
                 Text("  \"name\": ")
                     .foregroundColor(jsonKeyColor)
-                + Text("Joseph Tao")
+                + Text("\"Joseph Tao\",")
                     .foregroundColor(jsonValueColor)
                 
                 // 處理 title 的多行顯示

--- a/NameCard/Joseph/JosephView.swift
+++ b/NameCard/Joseph/JosephView.swift
@@ -170,5 +170,5 @@ struct JosephView: View {
 
 // MARK: - 預覽 (Preview)
 #Preview {
-    NameCardView()
+    JosephView()
 }

--- a/NameCard/Joseph/JosephView.swift
+++ b/NameCard/Joseph/JosephView.swift
@@ -6,7 +6,7 @@
 import SwiftUI
 
 // 主視圖，用來呈現整張名片
-struct NameCardView: View {
+struct JosephView: View {
     
     // MARK: - 屬性 (Properties)
     
@@ -71,13 +71,13 @@ struct NameCardView: View {
             // 中間檔案標題
             Text("Name Card.json")
                 .font(.system(size: 14, weight: .medium, design: .monospaced))
-                .foregroundColor(secondaryTextColor)
+                .foregroundStyle(secondaryTextColor)
             
             Spacer()
 
             // 右側漢堡選單圖示
             Image(systemName: "line.3.horizontal")
-                .foregroundColor(secondaryTextColor)
+                .foregroundStyle(secondaryTextColor)
                 .frame(width: 60)
         }
         .frame(height: 40)
@@ -104,7 +104,7 @@ struct NameCardView: View {
             Image(systemName: "ellipsis")
         }
         .font(.system(size: 14))
-        .foregroundColor(secondaryTextColor)
+        .foregroundStyle(secondaryTextColor)
         .padding(.horizontal)
         .padding(.bottom, 8)
     }
@@ -123,45 +123,44 @@ struct NameCardView: View {
                 Text("7")
             }
             .font(.system(size: 16, design: .monospaced))
-            .foregroundColor(secondaryTextColor)
+            .foregroundStyle(secondaryTextColor)
             
             // 右側 JSON 程式碼
             VStack(alignment: .leading, spacing: 4) {
-//                Text("Business Card.json")
                 Text("{")
                 
                 // 使用 `+` 運算子組合不同顏色的 Text
                 Text("  \"name\": ")
-                    .foregroundColor(jsonKeyColor)
+                    .foregroundStyle(jsonKeyColor)
                 + Text("\"Joseph Tao\",")
-                    .foregroundColor(jsonValueColor)
+                    .foregroundStyle(jsonValueColor)
                 
                 // 處理 title 的多行顯示
                 HStack(alignment: .top, spacing: 0) {
                     Text("  \"title\": ")
-                        .foregroundColor(jsonKeyColor)
+                        .foregroundStyle(jsonKeyColor)
                     
                     HStack(alignment: .top, spacing: -30) {
                         Text("Captain Mars Vessel ")
                         Text("of the ")
                     }
-                    .foregroundColor(jsonValueColor)
+                    .foregroundStyle(jsonValueColor)
                 }
                 
                 HStack(alignment: .top, spacing: 0) {
                     Text("  \"linkedin\": ")
-                        .foregroundColor(jsonKeyColor)
+                        .foregroundStyle(jsonKeyColor)
                     
                     HStack(alignment: .top, spacing: -10) {
                         Text("linkedin in/jzzt")
                         Text(".com/")
                     }
-                        .foregroundColor(jsonValueColor)
+                        .foregroundStyle(jsonValueColor)
                 }
                 Text("}")
             }
             .font(.system(size: 16, weight: .medium, design: .monospaced))
-            .foregroundColor(defaultTextColor)
+            .foregroundStyle(defaultTextColor)
             // 使用 .leading 對齊，確保程式碼靠左
             .frame(maxWidth: .infinity, alignment: .leading)
         }

--- a/NameCard/Joseph/JosephView.swift
+++ b/NameCard/Joseph/JosephView.swift
@@ -1,5 +1,3 @@
-//
-//  JojoView.swift
 //  NameCard
 //
 //  Created by Joseph-M2 on 2025/9/9.
@@ -8,7 +6,7 @@
 import SwiftUI
 
 // 主視圖，用來呈現整張名片
-struct BusinessCardView: View {
+struct NameCardView: View {
     
     // MARK: - 屬性 (Properties)
     
@@ -116,11 +114,10 @@ struct BusinessCardView: View {
         HStack(alignment: .top, spacing: 10) {
             // 左側行號
             VStack(alignment: .trailing, spacing: 4) {
-                // 圖片中的行號是不連續的，這裡忠實還原
                 Text("1")
                 Text("2")
                 Text("3")
-                Text("4") // title 的第二行沒有行號，所以這裡對應 linkedin
+                Text("4")
                 Text("5")
                 Text("6")
                 Text("7")
@@ -174,5 +171,5 @@ struct BusinessCardView: View {
 
 // MARK: - 預覽 (Preview)
 #Preview {
-    BusinessCardView()
+    NameCardView()
 }


### PR DESCRIPTION
這個拉取請求在 `NameCard/Joseph/JosephView.swift` 檔案中引入了一個名為 `NameCardView` 的新 SwiftUI 視圖。該視圖設計為以程式編輯器視窗風格呈現的名片，包含類 macOS 的標題列、工具列，以及顯示 JSON 格式資訊的程式碼區域。

用於名片顯示的新 UI 元件：

* 新增了 `NameCardView` SwiftUI 結構，它組合了一個包含背景、圓角和陰影效果的名片介面，呈現出精緻的視覺效果。

類似編輯器的介面元素：

* 實作了一個自訂標題列，採用 macOS 風格的交通燈按鈕、檔案名稱和選單圖示。
* 新增了一個包含常見編輯器圖示的工具列（復原、文件、大括號、導航箭頭等），提供真實的程式碼編輯器體驗。

語法高亮的程式碼區域：

* 開發了一個顯示行號和 JSON 內容的程式碼區域，使用不同顏色區分鍵和值，以模仿語法高亮效果。

預覽支援：

* 為 `NameCardView` 加入 SwiftUI 預覽功能，以方便視覺化測試與開發。