### PR TITLE
Add Roger's custom name card views and data

### DIFF
--- a/NameCard.xcodeproj/project.pbxproj
+++ b/NameCard.xcodeproj/project.pbxproj
@@ -261,7 +261,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -294,7 +294,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/NameCard/Roger/RogerContactRow.swift
+++ b/NameCard/Roger/RogerContactRow.swift
@@ -1,0 +1,27 @@
+//
+//  RogerContactRow.swift
+//  NameCard
+//
+//  Created by Roger on 12/30/24.
+//
+
+import SwiftUI
+
+struct RogerContactRow: View {
+    let icon: String
+    let text: String
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: icon)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(.white.opacity(0.9))
+                .frame(width: 16)
+            
+            Text(text)
+                .font(.system(size: 13, weight: .medium, design: .rounded))
+                .foregroundStyle(.white.opacity(0.95))
+                .lineLimit(1)
+        }
+    }
+}

--- a/NameCard/Roger/RogerNameCardBack.swift
+++ b/NameCard/Roger/RogerNameCardBack.swift
@@ -1,0 +1,92 @@
+//
+//  RogerNameCardBack.swift
+//  NameCard
+//
+//  Created by Roger on 12/30/24.
+//
+
+import SwiftUI
+
+struct RogerNameCardBack: View {
+    let contact: Contact
+    @State private var qrCodeScale: CGFloat = 0.8
+    @State private var organizationOpacity: Double = 0
+
+    var body: some View {
+        ZStack {
+            // Modern gradient background matching front
+            LinearGradient(
+                colors: [
+                    Color(.systemTeal).opacity(0.6),
+                    Color(.systemPurple).opacity(0.4),
+                    Color(.systemBlue).opacity(0.8)
+                ],
+                startPoint: .topTrailing,
+                endPoint: .bottomLeading
+            )
+            
+            VStack(spacing: 24) {
+                Spacer()
+                
+                // Organization info with modern styling
+                VStack(spacing: 16) {
+                    Text(contact.organization)
+                        .font(.system(size: 20, weight: .semibold, design: .rounded))
+                        .foregroundStyle(.white)
+                        .multilineTextAlignment(.center)
+                        .opacity(organizationOpacity)
+                        .shadow(color: .black.opacity(0.3), radius: 2, x: 0, y: 1)
+
+                    Text(contact.department)
+                        .font(.system(size: 14, weight: .medium, design: .rounded))
+                        .foregroundStyle(.white.opacity(0.8))
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 8)
+                        .background(
+                            Capsule()
+                                .fill(.white.opacity(0.2))
+                        )
+                        .opacity(organizationOpacity)
+                }
+                
+                Spacer()
+
+                // QR Code section with modern design
+                VStack(spacing: 16) {
+                    ZStack {
+                        // QR Code background
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(.white)
+                            .frame(width: 100, height: 100)
+                            .shadow(color: .black.opacity(0.2), radius: 8, x: 0, y: 4)
+                        
+                        RogerQRCodeView(contactInfo: contact.toVCard())
+                            .frame(width: 90, height: 90)
+                            .scaleEffect(qrCodeScale)
+                    }
+
+                    Text("SCAN TO CONNECT")
+                        .font(.system(size: 11, weight: .semibold, design: .rounded))
+                        .foregroundStyle(.white.opacity(0.8))
+                        .tracking(1.5)
+                }
+
+                Spacer()
+            }
+            .padding(.horizontal, 28)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .scaleEffect(x: -1, y: 1) // Flip horizontally for correct reading when card is flipped
+        .onAppear {
+            // Animate QR code appearance
+            withAnimation(.interpolatingSpring(stiffness: 200, damping: 10).delay(0.3)) {
+                qrCodeScale = 1.0
+            }
+            
+            // Animate organization info
+            withAnimation(.easeInOut(duration: 0.8).delay(0.1)) {
+                organizationOpacity = 1.0
+            }
+        }
+    }
+}

--- a/NameCard/Roger/RogerNameCardFront.swift
+++ b/NameCard/Roger/RogerNameCardFront.swift
@@ -1,0 +1,115 @@
+//
+//  RogerNameCardFront.swift
+//  NameCard
+//
+//  Created by Roger on 12/30/24.
+//
+
+import SwiftUI
+import SafariServices
+
+struct RogerNameCardFront: View {
+    let contact: Contact
+    @State private var showingSafari = false
+    @State private var animateGradient = false
+
+    var body: some View {
+        ZStack {
+            // Animated gradient background
+            LinearGradient(
+                colors: [
+                    Color(.systemBlue).opacity(0.8),
+                    Color(.systemPurple).opacity(0.6),
+                    Color(.systemTeal).opacity(0.4)
+                ],
+                startPoint: animateGradient ? .topLeading : .bottomTrailing,
+                endPoint: animateGradient ? .bottomTrailing : .topLeading
+            )
+            .onAppear {
+                withAnimation(.easeInOut(duration: 3).repeatForever(autoreverses: true)) {
+                    animateGradient.toggle()
+                }
+            }
+            
+            VStack(alignment: .leading, spacing: 0) {
+                // Header section with modern typography
+                VStack(alignment: .leading, spacing: 12) {
+                    Text(contact.displayName)
+                        .font(.system(size: 28, weight: .bold, design: .rounded))
+                        .foregroundStyle(.white)
+                        .shadow(color: .black.opacity(0.3), radius: 2, x: 0, y: 1)
+                        .padding(.top, 24)
+
+                    Text(contact.title)
+                        .font(.system(size: 16, weight: .medium, design: .rounded))
+                        .foregroundStyle(.white.opacity(0.9))
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 6)
+                        .background(
+                            Capsule()
+                                .fill(.white.opacity(0.2))
+                                .backdrop(BlurEffect())
+                        )
+                }
+                .padding(.horizontal, 28)
+
+                Spacer()
+
+                // Contact information with modern styling
+                VStack(alignment: .leading, spacing: 8) {
+                    RogerContactRow(icon: "envelope.fill", text: contact.email)
+                    RogerContactRow(icon: "phone.fill", text: contact.phone)
+                    RogerContactRow(icon: "location.fill", text: contact.address)
+                    
+                    // Interactive website button
+                    Button(action: {
+                        showingSafari = true
+                    }) {
+                        HStack(spacing: 8) {
+                            Image(systemName: "globe")
+                                .font(.system(size: 12, weight: .medium))
+                                .foregroundStyle(.white)
+                            
+                            Text(contact.website)
+                                .font(.system(size: 13, weight: .medium, design: .rounded))
+                                .foregroundStyle(.white)
+                        }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                        .background(
+                            Capsule()
+                                .fill(.white.opacity(0.25))
+                                .overlay(
+                                    Capsule()
+                                        .strokeBorder(.white.opacity(0.3), lineWidth: 1)
+                                )
+                        )
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                }
+                .padding(.horizontal, 28)
+                .padding(.bottom, 28)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .sheet(isPresented: $showingSafari) {
+            RogerSafariView(url: URL(string: "https://\(contact.website)") ?? URL(string: "https://google.com")!)
+        }
+    }
+}
+
+// Custom backdrop effect for iOS 17+
+struct BlurEffect: UIViewRepresentable {
+    func makeUIView(context: Context) -> UIVisualEffectView {
+        UIVisualEffectView(effect: UIBlurEffect(style: .systemMaterial))
+    }
+    
+    func updateUIView(_ uiView: UIVisualEffectView, context: Context) {}
+}
+
+extension View {
+    func backdrop<T: View>(_ content: T) -> some View {
+        self.background(content)
+    }
+}

--- a/NameCard/Roger/RogerQRCodeView.swift
+++ b/NameCard/Roger/RogerQRCodeView.swift
@@ -1,0 +1,51 @@
+//
+//  RogerQRCodeView.swift
+//  NameCard
+//
+//  Created by Roger on 12/30/24.
+//
+
+import SwiftUI
+import CoreImage.CIFilterBuiltins
+
+struct RogerQRCodeView: View {
+    let contactInfo: String
+
+    var body: some View {
+        if let qrImage = generateQRCode(from: contactInfo) {
+            Image(uiImage: qrImage)
+                .interpolation(.none)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+        } else {
+            RoundedRectangle(cornerRadius: 8)
+                .fill(.white)
+                .overlay(
+                    Image(systemName: "qrcode")
+                        .font(.system(size: 32, weight: .medium))
+                        .foregroundStyle(.black.opacity(0.7))
+                )
+        }
+    }
+
+    private func generateQRCode(from string: String) -> UIImage? {
+        let context = CIContext()
+        let filter = CIFilter.qrCodeGenerator()
+
+        filter.message = Data(string.utf8)
+        filter.correctionLevel = "H" // High error correction for better scanning
+
+        if let outputImage = filter.outputImage {
+            // Scale up the QR code for crisp quality
+            let transform = CGAffineTransform(scaleX: 12, y: 12)
+            let scaledImage = outputImage.transformed(by: transform)
+
+            if let cgImage = context.createCGImage(scaledImage, from: scaledImage.extent) {
+                return UIImage(cgImage: cgImage)
+            }
+        }
+
+        return nil
+    }
+}

--- a/NameCard/Roger/RogerSafariView.swift
+++ b/NameCard/Roger/RogerSafariView.swift
@@ -1,0 +1,28 @@
+//
+//  RogerSafariView.swift
+//  NameCard
+//
+//  Created by Roger on 12/30/24.
+//
+
+import SwiftUI
+import SafariServices
+
+struct RogerSafariView: UIViewControllerRepresentable {
+    let url: URL
+
+    func makeUIViewController(context: Context) -> SFSafariViewController {
+        let config = SFSafariViewController.Configuration()
+        config.entersReaderIfAvailable = true
+        
+        let safariVC = SFSafariViewController(url: url, configuration: config)
+        safariVC.preferredControlTintColor = UIColor.systemBlue
+        safariVC.preferredBarTintColor = UIColor.systemBackground
+        
+        return safariVC
+    }
+
+    func updateUIViewController(_ uiViewController: SFSafariViewController, context: Context) {
+        // No updates needed
+    }
+}

--- a/NameCard/Roger/RogerView.swift
+++ b/NameCard/Roger/RogerView.swift
@@ -1,0 +1,91 @@
+//
+//  RogerView.swift
+//  NameCard
+//
+//  Created by Roger on 12/30/24.
+//
+
+import SwiftUI
+
+struct RogerView: View {
+    @State private var isFlipped = false
+    @State private var rotationAngle: Double = 0
+    @State private var cardScale: CGFloat = 1.0
+    
+    let contact: Contact
+
+    var body: some View {
+        ZStack {
+            // Modern gradient background
+            LinearGradient(
+                colors: [
+                    Color(.systemBlue).opacity(0.1),
+                    Color(.systemPurple).opacity(0.05),
+                    Color(.systemBackground)
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            .ignoresSafeArea()
+
+            // Name Card with modern iOS 17+ styling
+            ZStack {
+                if !isFlipped {
+                    // Front of card
+                    RogerNameCardFront(contact: contact)
+                        .opacity(isFlipped ? 0 : 1)
+                } else {
+                    // Back of card
+                    RogerNameCardBack(contact: contact)
+                        .opacity(isFlipped ? 1 : 0)
+                }
+            }
+            .frame(width: 360, height: 230)
+            .background(
+                // Modern card background with materials
+                RoundedRectangle(cornerRadius: 16)
+                    .fill(.regularMaterial)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 16)
+                            .strokeBorder(
+                                LinearGradient(
+                                    colors: [.white.opacity(0.3), .clear],
+                                    startPoint: .topLeading,
+                                    endPoint: .bottomTrailing
+                                ),
+                                lineWidth: 1
+                            )
+                    )
+            )
+            .shadow(
+                color: .black.opacity(0.15),
+                radius: 20,
+                x: 0,
+                y: 10
+            )
+            .scaleEffect(cardScale)
+            .rotation3DEffect(
+                .degrees(isFlipped ? 180 : 0),
+                axis: (x: 0, y: 1, z: 0),
+                perspective: 0.5
+            )
+            .onTapGesture {
+                withAnimation(.interpolatingSpring(stiffness: 200, damping: 15)) {
+                    isFlipped.toggle()
+                }
+                
+                // Subtle scale animation
+                withAnimation(.easeInOut(duration: 0.1)) {
+                    cardScale = 0.98
+                }
+                withAnimation(.easeInOut(duration: 0.1).delay(0.1)) {
+                    cardScale = 1.0
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    RogerView(contact: Contact.rogerSampleData)
+}

--- a/NameCard/Shared/Contact.swift
+++ b/NameCard/Shared/Contact.swift
@@ -56,4 +56,16 @@ extension Contact {
         website: "buildwithharry.com",
         department: "AI Coding"
     )
+    
+    static let rogerSampleData = Contact(
+        firstName: "Roger",
+        lastName: "Chen",
+        title: "Senior Smooth Replies Manager",
+        organization: "ChatGPT University",
+        email: "roger@liftwithroger.com",
+        phone: "+1-555-123-4567",
+        address: "San Francisco, CA",
+        website: "elkmr-code.github.io/Tutoring-Resume",
+        department: "Mom's Basement"
+    )
 }

--- a/NameCard/Shared/Person.swift
+++ b/NameCard/Shared/Person.swift
@@ -20,6 +20,7 @@ struct Person: Identifiable {
 
 extension Person {
     static let sampleData: [Person] = [
-        Person(name: "Harry", type: . teacher, contact: Contact.sampleData)
+        Person(name: "Harry", type: .teacher, contact: Contact.sampleData),
+        Person(name: "Roger", type: .teacher, contact: Contact.rogerSampleData)
     ]
 }

--- a/NameCard/Views/PeopleListView.swift
+++ b/NameCard/Views/PeopleListView.swift
@@ -63,7 +63,15 @@ struct PersonDetailView: View {
     var body: some View {
         Group {
             if let contact = person.contact {
-                HarryView(contact: contact)
+                // Route to appropriate name card view based on person's name
+                switch person.name.lowercased() {
+                case "harry":
+                    HarryView(contact: contact)
+                case "roger":
+                    RogerView(contact: contact)
+                default:
+                    HarryView(contact: contact) // Default fallback
+                }
             } else {
                 VStack {
                     Image(systemName: "person.fill")


### PR DESCRIPTION
Introduces a new set of SwiftUI views for Roger's name card, including front and back designs, QR code generation, and Safari integration. Adds Roger's sample contact data and updates the person list to route to Roger's custom card. Minor fix in project settings for deployment target formatting.

<img width="382" height="260" alt="image" src="https://github.com/user-attachments/assets/3a6c79a0-bebc-4249-b9fc-37445b9c6aca" />


<img width="386" height="342" alt="image" src="https://github.com/user-attachments/assets/1b2f9c29-a69c-41c5-a149-4d2daab9280e" />
